### PR TITLE
[IMP] OrderScreen: Made the orders details items into a flatlist for better usability

### DIFF
--- a/Store/src/screens/OrdersScreen.js
+++ b/Store/src/screens/OrdersScreen.js
@@ -1,234 +1,226 @@
-import React, { useState } from 'react';
-import { StyleSheet, View, Text, TouchableOpacity } from 'react-native'
+import React, {useState} from 'react';
+import {StyleSheet, View, Text, TouchableOpacity, FlatList} from 'react-native';
 import colors from '../utils/Colors';
-import Icon from 'react-native-vector-icons/FontAwesome'
-import { color } from 'react-native-reanimated';
+import Icon from 'react-native-vector-icons/FontAwesome';
 
+const OrdersScreen = ({navigation}) => {
+  const [selectedOrder, setSelectedOrder] = useState(null);
 
-const OrdersScreen = ({ navigation }) => {
-    const [order1, setOrder1] = useState();
-    const [order2, setOrder2] = useState();
-    const [order3, setOrder3] = useState();
-    const products = [
+  const orders = [
+    {
+      key: "1",
+      order: 'Order#123',
+      //delivery could be static
+      delivery: 134,
+      details: [
         {
-            key: 1,
-            name: 'Apple',
-            price: 10.00,
-            quantity: '1 kg',
+          name: 'Apple',
+          price: 12,
+          quantity: 5,
+          metric: 'kg',
         },
         {
-            key: 2,
-            name: 'Dried',
-            price: 20.00,
-            quantity: '5 kg',
+          name: 'Orange',
+          price: 14,
+          quantity: 1,
+          metric: 'kg',
         },
         {
-            key: 3,
-            name: 'Cabbage',
-            price: 45.99,
-            quantity: '3 kg',
+          name: 'Eggs',
+          price: 12,
+          quantity: 3,
+          metric: 'kg',
+        },
+      ],
+      // somewhere else on the app needs to get the sum of all the products
+      // so we have the static calculated value here
+      total_price: 110,
+    },
+    {
+      key: "2",
+      order: 'Order#1235',
+      delivery: 124,
+      details: [
+        {
+          name: 'Watermelon',
+          price: 20,
+          quantity: 1,
+          metric: 'kg',
         },
         {
-            key: 4,
-            name: 'Eggs',
-            price: 15.00,
-            quantity: '1/2 kg',
+          name: 'Salt',
+          price: 4,
+          quantity: 500,
+          metric: 'g',
         },
         {
-            key: 5,
-            name: 'Pasta',
-            price: 13,
-            quantity: '1/2 kg',
+          name: 'Eggs',
+          price: 12,
+          quantity: 5,
+          metric: 'kg',
         },
-    ];
+      ],
+      total_price: 82,
+    },
+    {
+      key: "3",
+      order: 'Order#125',
+      delivery: 190,
+      details: [
+        {
+          name: 'Watermelon',
+          price: 20,
+          quantity: 1,
+          metric: 'kg',
+        },
+        {
+          name: 'Salt',
+          price: 4,
+          quantity: 500,
+          metric: 'g',
+        },
+        {
+          name: 'Eggs',
+          price: 12,
+          quantity: 5,
+          metric: 'kg',
+        },
+      ],
+      total_price: 82,
+    },
+  ];
 
+  const Order = ({order, details, delivery, total, onPress, show}) => (
+    <TouchableOpacity onPress={onPress}>
+      <View style={{flexDirection: 'row', justifyContent: 'space-between'}}>
+        <Text style={{color: colors.darkGray, fontSize: 17}}>{order}</Text>
+        <Icon
+          name="chevron-down"
+          color={colors.gray}
+          style={{alignSelf: 'center'}}></Icon>
+      </View>
+      <View
+        style={[show ? {display: 'flex'} : {display: 'none'}, {marginTop: 10}]}>
+        <FlatList
+          data={details}
+          keyExtractor={(item) => item.name}
+          renderItem={({item}) => (
+            <View style={[styles.accordionItem, {flexDirection: 'row'}]}>
+              <Text style={{fontSize: 16, color: colors.darkGray}}>
+                {item.name}
+              </Text>
+              <View style={{flexDirection: 'row'}}>
+                <Text
+                  style={{
+                    fontSize: 16,
+                    color: colors.gray,
+                    marginRight: 30,
+                  }}>
+                  {item.quantity} {item.metric}
+                </Text>
+                <Text style={{fontSize: 16, color: colors.darkGray}}>
+                  ${item.price}
+                </Text>
+              </View>
+            </View>
+          )}
+        />
+        <View style={{marginTop: 30}}>
+          <View
+            style={[
+              styles.accordionItem,
+              {flexDirection: 'row', justifyContent: 'flex-end'},
+            ]}>
+            <View style={{flexDirection: 'row'}}>
+              <Text style={{fontSize: 16, color: colors.gray, marginRight: 30}}>
+                Delivery
+              </Text>
+              <Text style={{fontSize: 16, color: colors.darkGray}}>
+                ${delivery}
+              </Text>
+            </View>
+          </View>
+          <View
+            style={[
+              styles.accordionItem,
+              {flexDirection: 'row', justifyContent: 'flex-end'},
+            ]}>
+            <View style={{flexDirection: 'row'}}>
+              <Text style={{fontSize: 16, color: colors.gray, marginRight: 30}}>
+                Total
+              </Text>
+              <Text style={{fontSize: 16, color: colors.darkGray}}>
+                ${total + delivery}
+              </Text>
+            </View>
+          </View>
+          <View style={{marginTop: -30}}>
+            <View
+              style={{flexDirection: 'row', justifyContent: 'space-between'}}>
+              <View style={{flexDirection: 'row'}}>
+                <Icon
+                  name="check-circle"
+                  color={colors.teal}
+                  style={{fontSize: 30, marginRight: 20}}></Icon>
+                <Text style={{fontSize: 16, color: colors.teal}}>Shipped</Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </TouchableOpacity>
+  );
+
+  const RenderOrders = ({item}) => {
+    const show = item.key === selectedOrder ? true : false;
     return (
-        <View>
-            <Text style={styles.title}> Your Orders </Text>
-            <View style={styles.accordion}>
-                <TouchableOpacity onPress={(value) => setOrder1(!order1)}>
-                    <View style={{ flexDirection: 'row', justifyContent: "space-between", }}>
-                        <Text style={{ color: colors.darkGray, fontSize: 17 }}>Orden #4567</Text>
-                        <Icon name="chevron-down" color={colors.gray} style={{ alignSelf: "center" }}></Icon>
-                    </View>
-                    <View style={[order1 ? { display: "flex" } : { display: "none" }, { marginTop: 10 }]}>
-                        <View style={[styles.accordionItem, { flexDirection: "row" }]}>
-                            <Text style={{ fontSize: 16, color: colors.darkGray }}>{products[0].name}</Text>
-                            <View style={{ flexDirection: "row" }}>
-                                <Text style={{ fontSize: 16, color: colors.gray, marginRight: 30 }}>{products[0].quantity}</Text>
-                                <Text style={{ fontSize: 16, color: colors.darkGray }}>${products[0].price}</Text>
-                            </View>
-                        </View>
-                        <View style={[styles.accordionItem, { flexDirection: "row" }]}>
-                            <Text style={{ fontSize: 16, color: colors.darkGray }}>{products[1].name}</Text>
-                            <View style={{ flexDirection: "row" }}>
-                                <Text style={{ fontSize: 16, color: colors.gray, marginRight: 30 }}>{products[1].quantity}</Text>
-                                <Text style={{ fontSize: 16, color: colors.darkGray }}>${products[1].price}</Text>
-                            </View>
-                        </View>
-                        <View style={[styles.accordionItem, { flexDirection: "row" }]}>
-                            <Text style={{ fontSize: 16, color: colors.darkGray }}>{products[2].name}</Text>
-                            <View style={{ flexDirection: "row" }}>
-                                <Text style={{ fontSize: 16, color: colors.gray, marginRight: 30 }}>{products[2].quantity}</Text>
-                                <Text style={{ fontSize: 16, color: colors.darkGray }}>${products[2].price}</Text>
-                            </View>
-                        </View>
-                        <View style={{ marginTop: 30 }}>
-                            <View style={[styles.accordionItem, { flexDirection: "row", justifyContent: "flex-end" }]}>
-                                <View style={{ flexDirection: "row" }}>
-                                    <Text style={{ fontSize: 16, color: colors.gray, marginRight: 30 }}>Delivery</Text>
-                                    <Text style={{ fontSize: 16, color: colors.darkGray }}>${products[3].price}</Text>
-                                </View>
-                            </View>
-                            <View style={[styles.accordionItem, { flexDirection: "row", justifyContent: "flex-end" }]}>
-                                <View style={{ flexDirection: "row" }}>
-                                    <Text style={{ fontSize: 16, color: colors.gray, marginRight: 30, }}>Total</Text>
-                                    <Text style={{ fontSize: 16, color: colors.darkGray }}>${products[4].price}</Text>
-                                </View>
-                            </View>
-                            <View style={{ marginTop: -30 }}>
-                                <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
-                                    <View style={{ flexDirection: 'row' }}>
-                                        <Icon name="check-circle" color={colors.teal} style={{ fontSize: 30, marginRight: 20 }}></Icon>
-                                        <Text style={{ fontSize: 16, color: colors.teal }}>Shipped</Text>
-                                    </View>
-                                </View>
-                            </View>
-                        </View>
-                    </View>
-                </TouchableOpacity>
-            </View >
-            <View style={styles.accordion}>
-                <TouchableOpacity onPress={(value) => setOrder2(!order2)}>
-                    <View style={{ flexDirection: 'row', justifyContent: "space-between", }}>
-                        <Text style={{ color: colors.darkGray, fontSize: 17 }}>Orden #4567</Text>
-                        <Icon name="chevron-down" color={colors.gray} style={{ alignSelf: "center" }}></Icon>
-                    </View>
-                    <View style={[order2 ? { display: "flex" } : { display: "none" }, { marginTop: 10 }]}>
-                        <View style={[styles.accordionItem, { flexDirection: "row" }]}>
-                            <Text style={{ fontSize: 16, color: colors.darkGray }}>{products[0].name}</Text>
-                            <View style={{ flexDirection: "row" }}>
-                                <Text style={{ fontSize: 16, color: colors.gray, marginRight: 30 }}>{products[0].quantity}</Text>
-                                <Text style={{ fontSize: 16, color: colors.darkGray }}>${products[0].price}</Text>
-                            </View>
-                        </View>
-                        <View style={[styles.accordionItem, { flexDirection: "row" }]}>
-                            <Text style={{ fontSize: 16, color: colors.darkGray }}>{products[1].name}</Text>
-                            <View style={{ flexDirection: "row" }}>
-                                <Text style={{ fontSize: 16, color: colors.gray, marginRight: 30 }}>{products[1].quantity}</Text>
-                                <Text style={{ fontSize: 16, color: colors.darkGray }}>${products[1].price}</Text>
-                            </View>
-                        </View>
-                        <View style={[styles.accordionItem, { flexDirection: "row" }]}>
-                            <Text style={{ fontSize: 16, color: colors.darkGray }}>{products[2].name}</Text>
-                            <View style={{ flexDirection: "row" }}>
-                                <Text style={{ fontSize: 16, color: colors.gray, marginRight: 30 }}>{products[2].quantity}</Text>
-                                <Text style={{ fontSize: 16, color: colors.darkGray }}>${products[2].price}</Text>
-                            </View>
-                        </View>
-                        <View style={{ marginTop: 30 }}>
-                            <View style={[styles.accordionItem, { flexDirection: "row", justifyContent: "flex-end" }]}>
-                                <View style={{ flexDirection: "row" }}>
-                                    <Text style={{ fontSize: 16, color: colors.gray, marginRight: 30 }}>Delivery</Text>
-                                    <Text style={{ fontSize: 16, color: colors.darkGray }}>${products[3].price}</Text>
-                                </View>
-                            </View>
-                            <View style={[styles.accordionItem, { flexDirection: "row", justifyContent: "flex-end" }]}>
-                                <View style={{ flexDirection: "row" }}>
-                                    <Text style={{ fontSize: 16, color: colors.gray, marginRight: 30, }}>Total</Text>
-                                    <Text style={{ fontSize: 16, color: colors.darkGray }}>${products[4].price}</Text>
-                                </View>
-                            </View>
-                            <View style={{ marginTop: -30 }}>
-                                <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
-                                    <View style={{ flexDirection: 'row' }}>
-                                        <Icon name="check-circle" color={colors.teal} style={{ fontSize: 30, marginRight: 20 }}></Icon>
-                                        <Text style={{ fontSize: 16, color: colors.teal }}>Shipped</Text>
-                                    </View>
-                                </View>
-                            </View>
-                        </View>
-                    </View>
-                </TouchableOpacity>
-            </View >
-            <View style={styles.accordion}>
-                <TouchableOpacity onPress={(value) => setOrder3(!order3)}>
-                    <View style={{ flexDirection: 'row', justifyContent: "space-between", }}>
-                        <Text style={{ color: colors.darkGray, fontSize: 17 }}>Orden #4567</Text>
-                        <Icon name="chevron-down" color={colors.gray} style={{ alignSelf: "center" }}></Icon>
-                    </View>
-                    <View style={[order3 ? { display: "flex" } : { display: "none" }, { marginTop: 10 }]}>
-                        <View style={[styles.accordionItem, { flexDirection: "row" }]}>
-                            <Text style={{ fontSize: 16, color: colors.darkGray }}>{products[0].name}</Text>
-                            <View style={{ flexDirection: "row" }}>
-                                <Text style={{ fontSize: 16, color: colors.gray, marginRight: 30 }}>{products[0].quantity}</Text>
-                                <Text style={{ fontSize: 16, color: colors.darkGray }}>${products[0].price}</Text>
-                            </View>
-                        </View>
-                        <View style={[styles.accordionItem, { flexDirection: "row" }]}>
-                            <Text style={{ fontSize: 16, color: colors.darkGray }}>{products[1].name}</Text>
-                            <View style={{ flexDirection: "row" }}>
-                                <Text style={{ fontSize: 16, color: colors.gray, marginRight: 30 }}>{products[1].quantity}</Text>
-                                <Text style={{ fontSize: 16, color: colors.darkGray }}>${products[1].price}</Text>
-                            </View>
-                        </View>
-                        <View style={[styles.accordionItem, { flexDirection: "row" }]}>
-                            <Text style={{ fontSize: 16, color: colors.darkGray }}>{products[2].name}</Text>
-                            <View style={{ flexDirection: "row" }}>
-                                <Text style={{ fontSize: 16, color: colors.gray, marginRight: 30 }}>{products[2].quantity}</Text>
-                                <Text style={{ fontSize: 16, color: colors.darkGray }}>${products[2].price}</Text>
-                            </View>
-                        </View>
-                        <View style={{ marginTop: 30 }}>
-                            <View style={[styles.accordionItem, { flexDirection: "row", justifyContent: "flex-end" }]}>
-                                <View style={{ flexDirection: "row" }}>
-                                    <Text style={{ fontSize: 16, color: colors.gray, marginRight: 30 }}>Delivery</Text>
-                                    <Text style={{ fontSize: 16, color: colors.darkGray }}>${products[3].price}</Text>
-                                </View>
-                            </View>
-                            <View style={[styles.accordionItem, { flexDirection: "row", justifyContent: "flex-end" }]}>
-                                <View style={{ flexDirection: "row" }}>
-                                    <Text style={{ fontSize: 16, color: colors.gray, marginRight: 30, }}>Total</Text>
-                                    <Text style={{ fontSize: 16, color: colors.darkGray }}>${products[4].price}</Text>
-                                </View>
-                            </View>
-                            <View style={{ marginTop: -30 }}>
-                                <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
-                                    <View style={{ flexDirection: 'row' }}>
-                                        <Icon name="check-circle" color={colors.teal} style={{ fontSize: 30, marginRight: 20 }}></Icon>
-                                        <Text style={{ fontSize: 16, color: colors.teal }}>Shipped</Text>
-                                    </View>
-                                </View>
-                            </View>
-                        </View>
-                    </View>
-                </TouchableOpacity>
-            </View >
-        </View >
+      <View style={styles.accordion}>
+        <Order
+          onPress={() => setSelectedOrder(item.key)}
+          show={show}
+          order={item.order}
+          details={item.details}
+          delivery={item.delivery}
+          total={item.total_price}
+        />
+      </View>
     );
+  };
+
+  return (
+    <>
+      <Text style={styles.title}> Your Orders </Text>
+      <FlatList
+        data={orders}
+        renderItem={RenderOrders}
+        keyExtractor={(item) => item.key}
+        extraData={selectedOrder}
+      />
+    </>
+  );
 };
 
 const styles = StyleSheet.create({
-    title: {
-        textAlign: "center",
-        fontSize: 22,
-        color: colors.darkGray,
-        padding: 20,
-        marginBottom: 20
-    },
-    accordion: {
-        marginTop: 20,
-        marginLeft: 30,
-        marginRight: 30,
-        padding: 20,
-        backgroundColor: colors.white,
-        borderRadius: 13,
-        elevation: 20,
-    },
-    accordionItem: {
-        marginTop: 10,
-        justifyContent: 'space-between'
-    }
-})
+  title: {
+    textAlign: 'center',
+    fontSize: 22,
+    color: colors.darkGray,
+    padding: 20,
+    marginBottom: 20,
+  },
+  accordion: {
+    marginTop: 20,
+    marginLeft: 30,
+    marginRight: 30,
+    padding: 20,
+    backgroundColor: colors.white,
+    borderRadius: 13,
+    elevation: 20,
+  },
+  accordionItem: {
+    marginTop: 10,
+    justifyContent: 'space-between',
+  },
+});
 
 export default OrdersScreen;


### PR DESCRIPTION
# Description
What did you implemented/Why did you implemented this:
 - We had all the orders static, so it wasn't possible to have a better usability of that code
 - I made the orders into a flat list receiving a JSON, so it can be done in a better and practical way.
 
 Examples:
 - We have a JSON in the format
   ```json
     {
      "key": string,
      "order": string,
      "delivery": number,
      "details": [
        {
          "name": string,
          "price": number,
          "quantity": number,
          "metric": string,
        }
        ],
      "total_price": number,
    },
    ```
 - Why?: It is easier to access to the info into a flat list this way, we just need to add the new values and go through every item.
 
 # Testing
 None
 
  ## Screenshots 
Collapsed:
![image](https://user-images.githubusercontent.com/47955967/109583501-9dd41500-7ac5-11eb-9fa9-3280f559c1ee.png)

Expanded: 
![image](https://user-images.githubusercontent.com/47955967/109583642-d07e0d80-7ac5-11eb-98c2-a88aaabf4d60.png)


